### PR TITLE
try-catch and robust UDP-json parsing

### DIFF
--- a/ABMobility/Grid.pde
+++ b/ABMobility/Grid.pde
@@ -101,9 +101,23 @@ public class Grid {
     }
 
     JSONObject json = parseJSONObject(message); 
+    
+    // parseJSONObject returns null if unparsable (processing docs)
+    if(json == null) return;
+
     JSONArray grids = json.getJSONArray("grid"); // maps building location --> Building
+    if(grids == null) return;
+
     for(int i=0; i < grids.size(); i++) {
-      int buildingId = grids.getJSONArray(i).getInt(0);
+      int buildingId;
+      try{
+        grids.getJSONArray(i).getInt(0);
+      } catch (Exception e) {
+        // getInt(n) returns an exception, different from getJSONArray
+        // if getJSONArray(i) is null, we will catch this.
+        // I should return, not break
+        return
+      }
 
       if((buildingId >= 0) && (buildingId < PHYSICAL_BUILDINGS_COUNT)) {
         Building building = buildings.get(buildingId);
@@ -132,9 +146,13 @@ public class Grid {
     }
 
     if(dynamicSlider) {
-      JSONArray sliders = json.getJSONArray("slider");
-      state.slider = 1.0 - sliders.getFloat(0);
-
+      JSONArray sliders = son.getJSONArray("slider");
+      if(sliders == null) return;
+      try{
+        state.slider = 1.0 - sliders.getFloat(0);
+      } catch (Exception e){
+        return;
+      }
     }   
   }
     


### PR DESCRIPTION
Compatible with Processing’s APIs around JSON Format. ```parseJSONObject```, ```getJSONObject()``` and ```getJSONArray()``` returns null if there isn’t a object, or original string unparseable. Where ```getFloat()```, ```getInt()``` returns an exception.

All mines are avoided with ```return```, not a ```break```, to simply ignore corrupted JSON inputs.